### PR TITLE
Allow recreating containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,46 @@ This might not be desirable, especially if you have a large amount of containers
 If you enable the `FILTER_BY_LABEL` setting, you can select which containers should be monitored by giving them the label `gantry-crane.enable=true`.
 This can be done via [docker](https://docs.docker.com/engine/reference/commandline/run/#set-metadata-on-container--l---label---label-file) or [docker-compose](https://docs.docker.com/compose/compose-file/compose-file-v3/#labels).
 
+## Monitoring containers via MQTT
+
+Information about each container is published in JSON format on a subtopic of the configured base topic.
+
+If the base topic is `gantry-crane` and a container is named `my_container`, the following is an example payload that would be published on the topic `gantry-crane/my_container`.
+
+```
+{
+  "name": "my_container",
+  "image": "philw07/gantry-crane:latest",
+  "state": "running",
+  "health": "unknown",
+  "cpu_percentage": 0.9,
+  "mem_percentage": 0.08,
+  "mem_mb": 12.51,
+  "net_rx_mb": 9.92,
+  "net_tx_mb": 9.55,
+  "block_rx_mb": 10.89,
+  "block_tx_mb": 8.31
+}
+```
+
+## Controlling containers via MQTT
+
+Containers can be controlled by publishing a non-retained message on the subtopic `set` for a container.
+
+For the example above, the topic would be `gantry-crane/my_container/set`.
+
+The following actions are available.
+
+| Payload | Description |
+| --- | --- |
+| `start` | Start the container. |
+| `stop` | Stop the container. |
+| `restart` | Restart the container. |
+| `pause` | Pause the container. |
+| `unpause` | Unpause the container. |
+| `recreate` | Recreate the container. The old container will be deleted and a new one created with the same configuration. |
+| `pull_recreate` | Pull the latest version of the image used for the container and then recreate the container using the new image. |
+
 ## Home Assistant integration
 
 When enabling the Home Assistant integration, by setting `HOMEASSISTANT_ACTIVE` to true, gantry-crane will publish MQTT discovery topics which Home Assistant will pick up automatically and add each container as a device with several entities (sensors and buttons).

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -22,6 +22,14 @@ pub const DOCKER_EVENT_ACTION_PAUSE: &str = "pause";
 pub const DOCKER_EVENT_ACTION_UNPAUSE: &str = "unpause";
 pub const DOCKER_NETWORK_MODE_HOST: &str = "host";
 
+pub const CONTAINER_REQUEST_START: &str = DOCKER_EVENT_ACTION_START;
+pub const CONTAINER_REQUEST_STOP: &str = DOCKER_EVENT_ACTION_STOP;
+pub const CONTAINER_REQUEST_RESTART: &str = DOCKER_EVENT_ACTION_RESTART;
+pub const CONTAINER_REQUEST_PAUSE: &str = DOCKER_EVENT_ACTION_PAUSE;
+pub const CONTAINER_REQUEST_UNPAUSE: &str = DOCKER_EVENT_ACTION_UNPAUSE;
+pub const CONTAINER_REQUEST_RECREATE: &str = "recreate";
+pub const CONTAINER_REQUEST_PULL_RECREATE: &str = "pull_recreate";
+
 // These numbers should be more than sufficient for the usual home setup
 pub const BUFFER_SIZE_EVENT_CHANNEL: usize = 1024;
 pub const BUFFER_SIZE_POLL_CHANNEL: usize = 8;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -32,6 +32,5 @@ pub const CONTAINER_REQUEST_PULL_RECREATE: &str = "pull_recreate";
 
 // These numbers should be more than sufficient for the usual home setup
 pub const BUFFER_SIZE_EVENT_CHANNEL: usize = 1024;
-pub const BUFFER_SIZE_POLL_CHANNEL: usize = 8;
 pub const BUFFER_SIZE_MQTT_RECV: usize = 384;
 pub const BUFFER_SIZE_MQTT_SEND: i32 = 384;

--- a/src/events.rs
+++ b/src/events.rs
@@ -40,6 +40,9 @@ pub enum Event {
     PublishMqttMessage(MqttMessage),
     SubscribeMqttTopic(String),
     MqttConnected,
+    ForcePoll,
+    SuspendPolling,
+    ResumePolling,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/events.rs
+++ b/src/events.rs
@@ -7,14 +7,13 @@ pub type EventReceiver = Receiver<Event>;
 
 pub struct EventChannel {
     #[allow(dead_code)]
-    rx: EventReceiver,
-    tx: EventSender,
+    pub tx: EventSender,
 }
 
 impl EventChannel {
     pub fn new() -> Self {
-        let (tx, rx) = broadcast::channel::<Event>(BUFFER_SIZE_EVENT_CHANNEL);
-        Self { rx, tx }
+        let (tx, _rx) = broadcast::channel::<Event>(BUFFER_SIZE_EVENT_CHANNEL);
+        Self { tx }
     }
 
     pub fn get_receiver(&self) -> EventReceiver {


### PR DESCRIPTION
This PR adds two new commands to control containers via MQTT messages.
- `recreate` deletes the current container and creates a new one, taking over the configuration.
- `pull_recreate` pulls the latest image and then recreates the container with the new image.